### PR TITLE
Change double negative on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ However, there are a few special packages:
 ## Disclaimer
 
 **Please note that the settings provided by this repository are highly
-opinionated and designed to fit my needs. I don't recommend nobody to stick
+opinionated and designed to fit my needs. I don't recommend anyone to stick
 with my settings.** My suggestion on the use of this repository is to take
 it as a framework for setting your own dotfiles.
 


### PR DESCRIPTION
"I don't recommend nobody to stick with my settings" is a double negative sentence that may lead to confusion.
"I don't recommend anyone to stick with my settings" could be more appropiate.

Double negatives should be avoided in standard English.